### PR TITLE
add and configure html addon for components

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,7 +2,7 @@ const createCompiler = require('@storybook/addon-docs/mdx-compiler-plugin');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.js'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-storysource', '@storybook/addon-a11y'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-storysource', '@storybook/addon-a11y','@whitespace/storybook-addon-html'],
   webpackFinal: async (config) => {
     config.module.rules.push({
       test: /\.scss$/,

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,4 +21,10 @@ addParameters({
   docs: {
     theme: coopTheme,
   },
+  html: {
+    prettier: {
+      tabWidth: 4,
+      useTabs: false,
+    },
+  },
 });

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@testing-library/react": "^11.0.4",
     "@types/fs-extra": "^9.0.1",
     "@types/styled-components": "^5.1.0",
+    "@whitespace/storybook-addon-html": "^4.2.0",
     "auto": "^9.54.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.3.0",


### PR DESCRIPTION
Added html addon to sb with some minor config
Allows for raw html of stories to be displayed in a tab under each story